### PR TITLE
make `nock` work with `fetch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "request": "^2.83.0"
   },
   "devDependencies": {
+    "node-fetch": "^1.7.3",
     "react-scripts": "1.0.16"
   },
   "scripts": {

--- a/src/model/braziliex.js
+++ b/src/model/braziliex.js
@@ -28,14 +28,11 @@ export const getBidPriceBrex = (currency_pair) => {
   })
 }
 
-export const getPriceBrex = (currency_pair) => {
+export const getPriceBrex = async (currency_pair) => {
   const uri = braziliex.host+braziliex.ticker_uri+currency_pair
-  const options = { url: uri, json: true }
-  return new Promise(function(resolve, reject) {
-    request(options, (error, response, json) => {
-      if (!error && response.statusCode === 200) {
-        resolve(json.last)
-      }
-    })
-  })
+
+  const response = await fetch(uri)
+  const payload = await response.json()
+
+  return payload.last
 }

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,4 @@
+// use node-fetch on test enviroment (instead of isomorphic-fetch)
+// it works better with nock library
+import fetch from 'node-fetch'
+global.fetch = fetch


### PR DESCRIPTION
This PR fixes the test enviroment so we can use `fetch` on production code and properly mock requests using `nock` library.

The problem was that `nock` does not work with `isomorphic-fetch`, that is embedded by `create-react-app`. So, I changed the test environment to use `node-fetch` instead.

There is an example of refactoring of `request` library to `fetch`.

Next step is: complete removal of `request` library, and use fetch instead.